### PR TITLE
Fix load error

### DIFF
--- a/lyrics-fetcher-genius.el
+++ b/lyrics-fetcher-genius.el
@@ -29,7 +29,6 @@
 (require 'request)
 (require 'cl-lib)
 (require 'json)
-(require 'subr)
 (require 'seq)
 (require 'shr)
 (require 'f)


### PR DESCRIPTION
I got following error at loading lyrics-fetcher.el.

```
Load error for /tmp/lyrics-fetcher.el/lyrics-fetcher.el:
(error Loading file /usr/share/emacs/27.1/lisp/subr.elc failed to provide feature ‘subr’)
```

`(require 'subr)` raises exception and it is not necessary to load `subr.el`. Its functions are available by default.