### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/lyrics-fetcher-genius.el
+++ b/lyrics-fetcher-genius.el
@@ -151,7 +151,7 @@ contains `info-albumartist' or `info-artist' and `info-title'"
 If ASK is non-nil, prompt the user for a choice, otherwise select the
 first song."
   (when (not (= (cdr (assoc 'status (assoc 'meta data))) 200))
-    (error "Error: %" (cdr (assoc 'message (assoc 'meta data)))))
+    (error "Error: %s" (cdr (assoc 'message (assoc 'meta data)))))
   (let* ((results (cdr (assoc 'hits (assoc 'response data))))
          (results-songs (seq-filter
                          (lambda (entry)
@@ -260,7 +260,7 @@ to FOLDER and will be name \"cover_full.<extension>\".
 
 CALLBACK will be called with the path to the resulting file."
   (when (not (= (cdr (assoc 'status (assoc 'meta data))) 200))
-    (error "Error: %" (cdr (assoc 'message (assoc 'meta data)))))
+    (error "Error: %s" (cdr (assoc 'message (assoc 'meta data)))))
   (let ((url (cdr
               (assoc 'cover_art_url
                      (assoc 'album

--- a/lyrics-fetcher.el
+++ b/lyrics-fetcher.el
@@ -32,6 +32,7 @@
 (require 'lyrics-fetcher-genius)
 (require 'f)
 (require 'emms)
+(require 'emms-browser)
 
 (defgroup lyrics-fetcher ()
   "Fetch song and album covers."
@@ -113,6 +114,8 @@ As of now, genius.com is the only one available."
 
 (defvar lyrics-fetcher-current-track-method
   "Current track in the lyrics view buffer")
+
+(defvar lyrics-fetcher-current-track)
 
 ;;; Actual lyrics fetching
 (defun lyrics-fetcher-format-song-name (track)


### PR DESCRIPTION
```
In lyrics-fetcher--open-lyrics:
lyrics-fetcher.el:389:50:Warning: assignment to free variable
    ‘lyrics-fetcher-current-track’

In lyrics-fetcher-view-update-lyrics:
lyrics-fetcher.el:412:4:Warning: reference to free variable
    ‘lyrics-fetcher-current-track’

In end of data:
lyrics-fetcher.el:514:1:Warning: the function ‘emms-browser-bdata-at-point’ is
    not known to be defined.

In lyrics-fetcher-genius--get-data-from-response:
lyrics-fetcher-genius.el:154:57:Warning: ‘error’ called with 1 args to fill 0
    format field(s)

In lyrics-fetcher-genius--save-album-url:
lyrics-fetcher-genius.el:263:57:Warning: ‘error’ called with 1 args to fill 0
    format field(s)
```