### PR TITLE
fix: require neteasecloud backend

### DIFF
--- a/lyrics-fetcher.el
+++ b/lyrics-fetcher.el
@@ -45,6 +45,7 @@
 
 ;;; Code:
 (require 'lyrics-fetcher-genius)
+(require 'lyrics-fetcher-neteasecloud)
 (require 'f)
 (require 'emms)
 (require 'emms-browser)


### PR DESCRIPTION
I forgot to require neteasecloud backend in `lyrics-fetcher.el`, sorry.